### PR TITLE
Tests pass on Windows after fixing paths

### DIFF
--- a/test/common.py
+++ b/test/common.py
@@ -1,0 +1,12 @@
+import json
+import os
+import unittest
+
+
+class ParserTest(unittest.TestCase):
+
+    def build_mock_report(self, report):
+        path = os.path.join(os.path.dirname(__file__), 'test_data', report) + '.json'
+        path = os.path.abspath(path)
+        with open(path) as f:
+            return json.load(f)

--- a/test/test_matrix_parser.py
+++ b/test/test_matrix_parser.py
@@ -1,28 +1,22 @@
-import json
 import unittest
 
 from salesforce_reporting import MatrixParser
+from test.common import ParserTest
 
 
-class MatrixParserTest(unittest.TestCase):
-
-    def build_mock_report(self, fp):
-        with open(fp) as json_file:
-            report_data = json.load(json_file)
-        return report_data
-
+class MatrixParserTest(ParserTest):
     def test_check_report_type_incorrect(self):
-        self.assertRaises(ValueError, MatrixParser, self.build_mock_report('test/test_data/summary_basic_single_group.json'))
+        self.assertRaises(ValueError, MatrixParser, self.build_mock_report('summary_basic_single_group'))
 
     def test_get_col_total_col_found(self):
-        report = MatrixParser(self.build_mock_report('test/test_data/matrix_basic.json'))
+        report = MatrixParser(self.build_mock_report('matrix_basic'))
 
         col_total = report.get_col_total('September 2013')
 
         self.assertEquals(col_total, 120000)
 
     def test_get_col_total_nested_top_level(self):
-        report = MatrixParser(self.build_mock_report('test/test_data/matrix_complex.json'))
+        report = MatrixParser(self.build_mock_report('matrix_complex'))
 
         col_total = report.get_col_total('Q3-2013')
 
@@ -30,49 +24,49 @@ class MatrixParserTest(unittest.TestCase):
 
     @unittest.skip("Functionality not yet added")
     def test_get_col_total_nested_level_down(self):
-        report = MatrixParser(self.build_mock_report("test/test_data/matrix_complex.json"))
+        report = MatrixParser(self.build_mock_report("matrix_complex"))
 
         col_total = report.get_col_total('December 2013')
 
         self.assertAlmostEqual(col_total, 5739000000)
 
     def test_get_col_total_col_not_found_default(self):
-        report = MatrixParser(self.build_mock_report('test/test_data/matrix_basic.json'))
+        report = MatrixParser(self.build_mock_report('matrix_basic'))
 
         col_total = report.get_col_total('January 2015')
 
         self.assertIsNone(col_total)
 
     def test_get_col_total_col_not_found_user_set(self):
-        report = MatrixParser(self.build_mock_report('test/test_data/matrix_complex.json'))
+        report = MatrixParser(self.build_mock_report('matrix_complex'))
 
         col_total = report.get_col_total('Q1-2016', default='No data available for period selected.')
 
         self.assertEquals(col_total, 'No data available for period selected.')
 
     def test_get_row_total_row_found(self):
-        report = MatrixParser(self.build_mock_report('test/test_data/matrix_basic.json'))
+        report = MatrixParser(self.build_mock_report('matrix_basic'))
 
         row_total = report.get_row_total('New Customer')
 
         self.assertEquals(row_total, 1790000)
 
     def test_series_for_col(self):
-        matrix = MatrixParser(self.build_mock_report('test/test_data/matrix_basic.json'))
+        matrix = MatrixParser(self.build_mock_report('matrix_basic'))
 
         series = matrix.series_down('March 2014')
 
         self.assertEquals(series["New Customer"], 430000)
 
     def test_series_for_row(self):
-        matrix = MatrixParser(self.build_mock_report('test/test_data/matrix_basic.json'))
+        matrix = MatrixParser(self.build_mock_report('matrix_basic'))
 
         series = matrix.series_across('New Customer')
 
         self.assertEquals(series["May 2013"], 75000)
 
     def test_series_for_col_with_row_grouping(self):
-        matrix = MatrixParser(self.build_mock_report('test/test_data/matrix_basic.json'))
+        matrix = MatrixParser(self.build_mock_report('matrix_basic'))
 
         series = matrix.series_down('December 2013', row_groups='Existing Customer - Upgrade')
 
@@ -80,14 +74,14 @@ class MatrixParserTest(unittest.TestCase):
         self.assertEquals(series["Edge Communications"], 60000)
 
     def test_series_down_with_multiple_col_groupings(self):
-        matrix = MatrixParser(self.build_mock_report('test/test_data/matrix_complex.json'))
+        matrix = MatrixParser(self.build_mock_report('matrix_complex'))
 
         series = matrix.series_down(['Q4-2013', 'October 2013'])
 
         self.assertEquals(series["New Customer"], 0)
 
     def test_series_down_multiple_groupings_and_metrics(self):
-        matrix = MatrixParser(self.build_mock_report('test/test_data/matrix_complex.json'))
+        matrix = MatrixParser(self.build_mock_report('matrix_complex'))
 
         series_record_count = matrix.series_down(['Q4-2013', 'October 2013'], row_groups='Existing Customer - Upgrade',
                                                  value_position=2)
@@ -98,14 +92,14 @@ class MatrixParserTest(unittest.TestCase):
         self.assertEquals(series_annual_revenue["GenePoint"], 30000000)
 
     def test_series_across_multiple_row_groupings(self):
-        matrix = MatrixParser(self.build_mock_report('test/test_data/matrix_basic.json'))
+        matrix = MatrixParser(self.build_mock_report('matrix_basic'))
 
         series = matrix.series_across(["New Customer", "GenePoint"])
 
         self.assertEquals(series["December 2013"], 85000)
 
     def test_series_across_multiple_groupings_and_metrics(self):
-        matrix = MatrixParser(self.build_mock_report('test/test_data/matrix_complex.json'))
+        matrix = MatrixParser(self.build_mock_report('matrix_complex'))
 
         series = matrix.series_across(['New Customer', 'Express Logistics and Transport'],
                                       col_groups='Q1-2014', value_position=1)

--- a/test/test_report_parser.py
+++ b/test/test_report_parser.py
@@ -1,25 +1,18 @@
-import json
-import unittest
-
 from salesforce_reporting import ReportParser
+from test.common import ParserTest
 
 
-class ReportParserTest(unittest.TestCase):
-
-    def build_mock_report(self, fp):
-        with open(fp) as json_file:
-             report_data = json.load(json_file)
-        return report_data
+class ReportParserTest(ParserTest):
 
     def test_get_records_simple_tabular(self):
-        report = ReportParser(self.build_mock_report('test/test_data/tabular_basic.json'))
+        report = ReportParser(self.build_mock_report('tabular_basic'))
 
         records = report.records()
         self.assertEquals(len(records), 20)
         self.assertEquals(records[1][2], 'James')
 
     def test_get_record_dict_simple_tabular(self):
-        report = ReportParser(self.build_mock_report('test/test_data/tabular_basic.json'))
+        report = ReportParser(self.build_mock_report('tabular_basic'))
 
         records = report.records_dict()
         field_value = records[0]["Mailing Street"]
@@ -28,7 +21,7 @@ class ReportParserTest(unittest.TestCase):
         self.assertIsNotNone(field_value)
 
     def test_get_records_simple_summary(self):
-        report = ReportParser(self.build_mock_report('test/test_data/summary_basic_single_group.json'))
+        report = ReportParser(self.build_mock_report('summary_basic_single_group'))
 
         records = report.records()
 
@@ -36,7 +29,7 @@ class ReportParserTest(unittest.TestCase):
         self.assertEquals(records[0][0], 'Chris Hall')
 
     def test_get_record_dict_simple_summary(self):
-        report = ReportParser(self.build_mock_report('test/test_data/summary_basic_single_group.json'))
+        report = ReportParser(self.build_mock_report('summary_basic_single_group'))
 
         records = report.records_dict()
         field_value = records[0]["Created Date"]
@@ -45,31 +38,31 @@ class ReportParserTest(unittest.TestCase):
         self.assertIsNotNone(field_value)
 
     def test_get_records_basic_matrix(self):
-        report = ReportParser(self.build_mock_report('test/test_data/matrix_basic.json'))
+        report = ReportParser(self.build_mock_report('matrix_basic'))
 
         records = report.records()
 
         self.assertEquals(len(records), 18)
 
     def test_get_records_without_details(self):
-        report = ReportParser(self.build_mock_report('test/test_data/matrix_complex.json'))
+        report = ReportParser(self.build_mock_report('matrix_complex'))
 
         self.assertRaises(ValueError, report.records)
 
     def test_get_records_dict_without_details(self):
-        report = ReportParser(self.build_mock_report('test/test_data/matrix_complex.json'))
+        report = ReportParser(self.build_mock_report('matrix_complex'))
 
         self.assertRaises(ValueError, report.records_dict)
 
     def test_get_grand_total_on_summary_report(self):
-        report = ReportParser(self.build_mock_report('test/test_data/summary_basic_single_group.json'))
+        report = ReportParser(self.build_mock_report('summary_basic_single_group'))
 
         grand_total = report.get_grand_total()
 
         self.assertEquals(grand_total, 9469000000)
 
     def test_get_grand_total_on_matrix_report(self):
-        report = ReportParser(self.build_mock_report('test/test_data/matrix_basic.json'))
+        report = ReportParser(self.build_mock_report('matrix_basic'))
 
         grand_total = report.get_grand_total()
 


### PR DESCRIPTION
Also extracted the mock report building into a base class and removed the need for the Test subclasses to know anything about where the files are, or even in what format they are stored.