### PR TITLE
Correct the URL used to request the metadata used to request filtered reports

### DIFF
--- a/salesforce_reporting/login.py
+++ b/salesforce_reporting/login.py
@@ -112,7 +112,8 @@ class Connection:
         return requests.get(url + '/describe', headers=self.headers).json()
 
     def _get_report_filtered(self, url, filters):
-        metadata = self._get_metadata(url)
+        metadata_url = url.split('?')[0]
+        metadata = self._get_metadata(metadata_url)
         for report_filter in filters:
             metadata["reportMetadata"]["reportFilters"].append(report_filter)
 


### PR DESCRIPTION
This fixes issue #3.

In order to get a report with custom filters we must:
- request the metadata for the report;
- add the filters JSON to the metadata; and
- include this metadata in the POST request to get the report.

Currently the 'describe' endpoint being used to request the metadata is incorrect (it includes the `includeDetails` parameter) and so returns a different metadata file. SalesForce is not expecting this form of metadata file and so spits out an error.

This fix strips off the `includeDetails` parameter, leading to a valid metadata object being returned and SalesForce correctly interpreting the metadata.

Huzzah.