### PR TITLE
Fix API version bug

### DIFF
--- a/salesforce_reporting/login.py
+++ b/salesforce_reporting/login.py
@@ -38,7 +38,7 @@ class Connection:
         self.password = password
         self.security_token = security_token
         self.sandbox = sandbox
-        self.api_version = api_version
+        self.api_version = api_version.lstrip('v')
         self.login_details = self.login(self.username, self.password, self.security_token)
         self.token = self.login_details['oauth']
         self.instance = self.login_details['instance']


### PR DESCRIPTION
I noticed this library was generating requests to the soon-to-be-retired version 7 API, in spite of what the default api_version would have had me believe. I can open an issue if needed but i hope the description here makes the bug clear:

The login URL should not include the leading v in the api version, just the numeric part. 

(See docs at: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_calls_login.htm)

Including the leading v (as is the default behavior with the value "v29.0" results in salesforce returning a server_url with a version of 7.0, which  is being retired early next year. I've opted to leave the default value as is,  to avoid changing the library's interface, and just to change the implementation to generate the correct URL.